### PR TITLE
Used the timestamp of support-log as the filename

### DIFF
--- a/lib/gocd/monitor/api_support.rb
+++ b/lib/gocd/monitor/api_support.rb
@@ -66,7 +66,7 @@ module Gocd
       end
 
       def log_info_to_file(response)
-        time = Time.now.strftime('%Y%m%d_%H%M%S%z')
+        time = JSON.parse(response.body)["Timestamp"]
         filename = File.join(api_support_dir_name, time)
         filename <<  if response.headers['Content-Type'] =~ /\bjson\b/
           ".json"


### PR DESCRIPTION
The time of the machine where gocd-monitor is running could be different from the time of the gocd server.

Used the timestamp at which snapshot was taken as the support.log file name.